### PR TITLE
ADD: Support for latest (v0.3.5) goss at time of commit

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 # vars file for install_goss
 goss:
+  v0.3.5:
+    sha256sum: "5669df08e406abf594de0e7a7718ef389e5dc7cc76905e7f6f64711e6aad7fa3"
   v0.2.6:
     sha256sum: "d1ff74a14bccba4a016e66ef7023789582cc9923dd3a55aa5ea0c02b371b0a79"
   v0.2.5:


### PR DESCRIPTION
As title suggests.

Would be nice if @aelsabbahy published an accessible list of hashes for goss versions somewhere so this update didn't have to be manual. 